### PR TITLE
Add OpenShift install scripts - Prototype

### DIFF
--- a/openshift/Vagrantfile
+++ b/openshift/Vagrantfile
@@ -1,0 +1,112 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+MEMORY = 16384
+NUM_HOSTS = 2
+
+BOX = "centos/7"
+VAGRANTFILE_API_VERSION = '2'
+HOSTNAME_PREFIX = "os-node-"
+
+## BASE_IP_ADDR=172.28.128
+BASE_IP_ADDR = ENV.fetch('BASE_IP_ADDR')
+
+ips = Hash.new
+
+## Install required softwares for running install
+$install_deps= <<-SCRIPT
+  echo "\nInstalling required softwares\n"
+  yum install -y epel-release
+  yum install -y docker wget git sshpass
+  yum install -y "@Development Tools" python2-pip openssl-devel python-devel
+  pip install -Iv ansible==2.2.0.0
+  yum install -y python-cryptography pyOpenSSL.x86_64
+SCRIPT
+
+## Clone repos (anisble, etc.)
+$clone_repos= <<-SCRIPT
+  echo "\nClone repositories\n"
+  git clone https://github.com/openshift/openshift-ansible /root/openshift-ansible
+  (cd /root/openshift-ansible && git checkout origin/release-1.4)
+SCRIPT
+
+## Install openshift
+$install_openshift= <<-SCRIPT
+  echo "\nInstalling OpenShift\n"
+  cp /home/vagrant/inventory.erb /root/
+  ansible-playbook -i /root/inventory.erb /root/openshift-ansible/playbooks/byo/config.yml
+  sleep 5
+  echo "OpenShift Installation Successful!"
+
+  echo "\nLogin to OpenShift using \"oc login --username=system --password=admin\" from the master(os-node-2) node\n\n"
+
+  echo "Complete!"
+SCRIPT
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = BOX
+
+  (1..NUM_HOSTS).each do |i|
+    public_hostname = "#{HOSTNAME_PREFIX}#{i}.openshift.io"
+    ip = "#{BASE_IP_ADDR}.#{i+50}"
+
+    config.vm.define "#{HOSTNAME_PREFIX}#{i}" do |host|
+      host.vm.hostname = "#{HOSTNAME_PREFIX}#{i}"
+      host.vm.network "private_network", ip: "#{ip}"
+      host.vm.provider "virtualbox" do |vb, override|
+        vb.linked_clone = true if Vagrant::VERSION =~ /^1.8/
+        vb.name = host.vm.hostname # sets the name for virtualbox, VM can be accessed using this name in `vboxmanage`, yay!
+        vb.memory = MEMORY
+      end #vb
+
+
+      ## Prepare host 
+      $prepare_host=<<-SCRIPT
+        ifup eth1
+
+        echo "\nFetching IP address\n"
+        ip=$(ip addr | grep eth1 | grep -oE "([0-9]{1,3}\.){3}[0-9]{1,3}" | head -1)
+        echo "$ip #{public_hostname}" >> /etc/hosts
+
+        sed -re 's/^(PasswordAuthentication)([[:space:]]+)no/\\1\\2yes/' -i.`date -I` /etc/ssh/sshd_config
+        kill $(ps aux | grep /usr/sbin/sshd | head -1 | awk '{print $2}') && sudo /usr/sbin/sshd
+      SCRIPT
+
+      host.vm.provision "shell", inline: $prepare_host, privileged: true
+
+      if i == NUM_HOSTS then
+        host.vm.provision "file", source: "./inventory.erb", destination: "~/inventory.erb"
+
+        host.vm.provision "shell", inline: $install_deps, privileged: true
+
+        host.vm.provision "shell", inline: $clone_repos, privileged: true
+
+        ## Set passwordless ssh 
+        $set_passwordless_ssh= <<-SCRIPT
+          echo "\nSetting passwordless ssh for all the hosts from #{public_hostname}\n"
+          mkdir -p /root/.ssh && touch /root/.ssh/config
+          echo "StrictHostKeyChecking no" >> /root/.ssh/config
+          echo "UserKnownHostsFile=/dev/null" >> /root/.ssh/config
+          ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -N ''
+          sshpass -p vagrant ssh-copy-id -i /root/.ssh/id_rsa.pub root@#{public_hostname}
+        SCRIPT
+        host.vm.provision "shell", inline: $set_passwordless_ssh, privileged: true
+
+        ## Set passwordless SSH for all the worker nodes from master
+        ips.each do |ip, hostname|
+          $set_passwordless_ssh= <<-SCRIPT
+            echo "#{ip} #{hostname}" >> /etc/hosts
+            sshpass -p vagrant ssh-copy-id -i /root/.ssh/id_rsa.pub root@#{hostname}
+          SCRIPT
+
+          host.vm.provision "shell", inline: $set_passwordless_ssh, privileged: true
+        end #ip,hostname
+
+        host.vm.provision "shell", inline: $install_openshift, privileged: true
+      else 
+        ips[ip]= public_hostname
+      end #if
+    end #host
+  end #i
+end #config
+

--- a/openshift/inventory.erb
+++ b/openshift/inventory.erb
@@ -1,0 +1,25 @@
+[OSEv3:children]
+masters
+nodes
+
+[OSEv3:vars]
+ansible_ssh_user=root
+deployment_type=origin
+
+# Uncomment the following to enable htpasswd authentication; defaults to DenyAllPasswordIdentityProvider.
+# openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/master/htpasswd'}]
+
+containerized=true
+openshift_release=v1.4
+openshift_image_tag=v1.4.0
+openshift_public_hostname=os-node-2.openshift.io
+openshift_master_default_subdomain=apps.os-node-2.openshift.io
+openshift_hosted_metrics_deploy=false
+
+[masters]
+os-node-2.openshift.io
+
+[nodes]
+os-node-1.openshift.io openshift_node_labels="{'region': 'infra', 'zone': 'default'}" openshift_schedulable=true
+os-node-2.openshift.io openshift_node_labels="{'region': 'infra', 'zone': 'default'}" openshift_schedulable=true
+


### PR DESCRIPTION
Current install method creates 2 VM, one of which(os-node-2) is the master
and uses ansible to install OpenShift on them.

Test using `BASE_IP_ADDR=172.28.128 vagrant up`

Signed-off-by: Yuva Shankar <yuva29@users.noreply.github.com>